### PR TITLE
fixed the cronjob and added timestamps to logging

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# add a simple logger function
+# usage: log "message"
+log() {
+  echo "$(date) - $1"
+}
+
 echo "This script backs up a directory and encrypts it with aes-256-cbc"
 echo "It only keeps the latest backup around, previous ones are removed to save space"
 
@@ -66,9 +72,20 @@ file_name=$(echo "$file_name" | tr '/' '-')
 file_name=$(echo "$file_name" | tr '[:upper:]' '[:lower:]') # replace slashes with dashes, and make lowercase
 
 # make sure work is done in the temp directory
-echo "backing up: $dir_path"
-echo "writing temporarily to: $(pwd)/temp/$file_name.zip"
-echo "will store encrypted backup in $output_path when done"
+log "backing up: $dir_path"
+log "writing temporarily to: $(pwd)/temp/$file_name.zip"
+log "will store encrypted backup in $output_path when done"
+
+# load the encryption key from .env file
+source ".env"
+
+# check if ENCRYPTION_KEY parameter is set
+if [ -z "$ENCRYPTION_KEY" ]; then
+  log "Missing ENCRYPTION_KEY in either the environment, or .env file"
+  log "Please add ENCRYPTION_KEY='your encryption key' to the .env file"
+  log "Be sure to save the key somewhere safe as the files won't be recoverable without it"
+  exit 1
+fi
 
 # first zip the directory
 cd $(pwd)/temp
@@ -76,7 +93,7 @@ zip --quiet --test --recurse-paths -0 $file_name $dir_path
 
 # stop if there was an issue creating the file
 if [ ! -f $file_name.zip ]; then
-  echo "$file_name.zip does not exist, something went wrong at the zip stage"
+  log "$file_name.zip does not exist, something went wrong at the zip stage"
   exit 1
 fi
 
@@ -91,18 +108,7 @@ lrzip -L 9 $file_name.zip
 
 # check if the file was created
 if [ ! -f $file_name.zip.lrz ]; then
-  echo "lrzip had an error, journal.zip.lrz does not exist"
-  exit 1
-fi
-
-# load the encryption key from .env file
-source "../.env"
-
-# check if ENCRYPTION_KEY parameter is set
-if [ -z "$ENCRYPTION_KEY" ]; then
-  echo "Missing ENCRYPTION_KEY in either the environment, or .env file"
-  echo "Please add ENCRYPTION_KEY='your encryption key' to the .env file"
-  echo "Be sure to save the key somewhere safe as the files won't be recoverable without it"
+  log "lrzip had an error, journal.zip.lrz does not exist"
   exit 1
 fi
 
@@ -114,16 +120,16 @@ openssl enc -aes-256-cbc -iv $IV -in $file_name.zip.lrz -out $file_name.zip.lrz.
 
 # check if the file was created
 if [ ! -f $file_name.zip.lrz.enc.$IV ]; then
-  echo "openssl had an error, $file_name.zip.lrz.enc.$IV does not exist"
+  log "openssl had an error, $file_name.zip.lrz.enc.$IV does not exist"
   exit 1
 fi
-echo "encrypted file with IV: $IV"
+log "encrypted file with IV: $IV"
 
 # rename the old backup if it exists
 old_backups=$(find "$output_path" -type f -name "$file_name.zip.lrz.enc.*")
 if [ ! -z "$old_backups" ]; then
   while read -r old_backup; do
-    echo "found previous backup, renaming to $old_backup.old"
+    log "found previous backup, renaming to $old_backup.old"
     mv "$old_backup" "$old_backup.old"
   done <<< "$old_backups"
 fi
@@ -133,16 +139,16 @@ mv $file_name.zip.lrz.enc.$IV "$output_path"
 
 # check that it's there
 if [ ! -f "$output_path/$file_name.zip.lrz.enc.$IV" ]; then
-  echo "$output_path/$file_name.zip.lrz.enc.$IV does not exist, something went wrong"
-  echo "the previous output is still there, with the .old extension"
+  log "$output_path/$file_name.zip.lrz.enc.$IV does not exist, something went wrong"
+  log "the previous output is still there, with the .old extension"
   exit 1
 fi
-echo "moved encrypted file to $output_path/$file_name.zip.lrz.enc.$IV"
+log "moved encrypted file to $output_path/$file_name.zip.lrz.enc.$IV"
 
 # remove old backups
 if [ ! -z "$old_backups" ]; then
   while read -r old_backup; do
-    echo "removing old backups $old_backup.old"
+    log "removing old backups $old_backup.old"
     rm "$old_backup.old"
   done <<< "$old_backups"
 fi
@@ -151,47 +157,50 @@ fi
 temp_files=$(find "." -type f -name "$file_name.*")
 if [ ! -z "$temp_files" ]; then
   while read -r temp_file; do
-    echo "removing temporary file: $temp_file"
+    log "removing temporary file: $temp_file"
     rm $temp_file
   done <<< "$temp_files"
 fi
 
 # This is the function for scheduling backups (if needed)
 schedule_cronjob() {
-  echo "\nInspecting the current crontab:"
+  log "\nInspecting the current crontab:"
   crontab -l
   # note that the script was running in it's temp directory, so back out to the base directory
   cd ../ # there is probably a better way to do this
-  script_path="$(pwd)/$(basename "$0")"
+  base_path=$(pwd)
+  script_name="backup.sh"
+
   # check if journal-backup/backup.sh is already added to the crontab
-  cron_str="0 $backup_hour * * * $script_path -d \"$dir_path\" -o \"$output_path\""
-  echo "checking if crontab has: $cron_str"
+  cron_str="0 $backup_hour * * * cd $base_path && ./$script_name -d \"$dir_path\" -o \"$output_path\""
+  log "checking if crontab has: $cron_str"
   if crontab -l | grep -q -F "$cron_str"; then
-    echo "\nbackup.sh is already scheduled"
-    echo "not doing anything to avoid duplicate schedules"
+    log "\nbackup.sh is already scheduled"
+    log "not doing anything to avoid duplicate schedules"
     exit 0
   fi
 
-  # check if /usr/bin is available in cron
-  if ! crontab -l | grep -q "/usr/bin"; then
-    if crontab -l | grep -q "PATH="; then
-      crontab -l | sed 's/\(PATH=.*\)/\1:\/usr\/bin/' | crontab -
+  # check if /usr/bin and /bin are available in cron
+  if ! crontab -l | grep -q "[:/usr/bin|:/bin]"; then
+    if crontab -l | grep -q "^PATH="; then
+      # path already exists, just add to it
+      crontab -l | sed 's/\(PATH=.*\)/\1:\/usr\/bin/:\/bin/' | crontab -
     else
       (
-        echo "PATH=/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
+        echo "PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
         crontab -l 2>/dev/null
       ) | crontab -
     fi
-    echo "\n/usr/bin was not available in cron, added it so that lrzip and zip will function"
+    log "/usr/bin was not available in cron, added it so that lrzip and zip will function"
   fi
 
-  echo "\nAdding backup.sh for hour of the day: $backup_hour"
+  log "\nAdding backup.sh for hour of the day: $backup_hour"
   (
     crontab -l 2>/dev/null
-    echo "0 $backup_hour * * * $script_path -d \"$dir_path\" -o \"$output_path\" > $(pwd)/logs/log.txt"
+    echo "$cron_str >> $(pwd)/logs/log.txt"
   ) | crontab -
 
-  echo "\nNew crontab:"
+  log "\nNew crontab:"
   crontab -l
 }
 
@@ -207,17 +216,17 @@ schedule_cronjob() {
 if [ ! -z "$backup_hour" ] && [ "$backup_hour" -eq "$backup_hour" ] 2>/dev/null && [ "$backup_hour" -ge 0 ] && [ "$backup_hour" -le 23 ]; then
   schedule_cronjob
 else
-  echo "\nNo backup hour provided, not scheduling a regular backup"
+  log "\nNo backup hour provided, not scheduling a regular backup"
 fi
 
 # trim the logfile if its gotten really long
 if [ -f "logs/log.txt" ]; then
   log_size=$(wc -c <"logs/log.txt")
   if [ $log_size -gt 1000000 ]; then
-    echo "trimming 100kb from the 1mb log.txt file, so that it doesn't grow too large"
+    log "trimming 100kb from the 1mb log.txt file, so that it doesn't grow too large"
     tail -c 900000 "logs/log.txt" > "logs/temp-log.txt"
     mv "logs/temp-log.txt" "logs/log.txt"
   fi
 fi
 
-echo "\nBackup and encryption complete"
+log "\nBackup and encryption complete"


### PR DESCRIPTION
**The Problem**

This addresses issue #2 

I also noticed that the log doesn't have timestamps, and it was hard to understand if I was looking at the correct log messages. I added timestamps to everything except for the initial echo statements that explain how to utilize the backup shell script.

**Solution**

- Added a log function that includes the date.
- Modified cron to change to the working directory before executing the shell script.
- Modified PATH variable so that it includes `/bin` - necessary for uses of `mv`

**Testing**

- I updated my crontab and validated that the script could run from start to finish when instantiated from there
- I ran the script on its own with the hour option (`-h 22`) to make sure that it would update cron with the correct schedule
- I validated the log messages had timestamps, and that I didn't accidentally replace any function echos (when providing strings to cron for example).  